### PR TITLE
Use stdint int64_t instead of int64

### DIFF
--- a/src/browser/resource_handler.cxx
+++ b/src/browser/resource_handler.cxx
@@ -5,7 +5,7 @@ bool Browser::ResourceHandler::Open(CefRefPtr<CefRequest>, bool& handle_request,
 	return true;
 }
 
-void Browser::ResourceHandler::GetResponseHeaders(CefRefPtr<CefResponse> response, int64& response_length, CefString& redirectUrl) {
+void Browser::ResourceHandler::GetResponseHeaders(CefRefPtr<CefResponse> response, int64_t& response_length, CefString& redirectUrl) {
 	response->SetStatus(this->status);
 	response->SetMimeType(this->mime);
 	if (this->has_location) {
@@ -35,7 +35,7 @@ bool Browser::ResourceHandler::Read(void* data_out, int bytes_to_read, int& byte
 	return true;
 }
 
-bool Browser::ResourceHandler::Skip(int64 bytes_to_skip, int64& bytes_skipped, CefRefPtr<CefResourceSkipCallback>) {
+bool Browser::ResourceHandler::Skip(int64_t bytes_to_skip, int64_t& bytes_skipped, CefRefPtr<CefResourceSkipCallback>) {
 	if (this->cursor + bytes_to_skip <= this->data_len) {
 		// skip in bounds
 		bytes_skipped = bytes_to_skip;

--- a/src/browser/resource_handler.hxx
+++ b/src/browser/resource_handler.hxx
@@ -21,9 +21,9 @@ namespace Browser {
 			ResourceHandler(file.contents, file.size, 200, file.mime_type) { this->file_manager = file_manager; }
 
 		bool Open(CefRefPtr<CefRequest>, bool&, CefRefPtr<CefCallback>) override;
-		void GetResponseHeaders(CefRefPtr<CefResponse>, int64&, CefString&) override;
+		void GetResponseHeaders(CefRefPtr<CefResponse>, int64_t&, CefString&) override;
 		bool Read(void*, int, int&, CefRefPtr<CefResourceReadCallback>) override;
-		bool Skip(int64, int64&, CefRefPtr<CefResourceSkipCallback>) override;
+		bool Skip(int64_t, int64_t&, CefRefPtr<CefResourceSkipCallback>) override;
 		void Cancel() override;
 		CefRefPtr<CefResourceHandler> GetResourceHandler(CefRefPtr<CefBrowser>, CefRefPtr<CefFrame>, CefRefPtr<CefRequest>) override;
 


### PR DESCRIPTION
As of https://github.com/chromiumembedded/cef/commit/e53bff712ad31494787977104818adc4d609a887 (Jun 1, 2023) `cef_basictypes.h` is removed which defines `int64`, so it will refuse to build on a newer CEF version. This PR switches the existing `int64` occurences to `int64_t`.