### PR TITLE
Remove explicit override to prevent build issues with newer CEF

### DIFF
--- a/src/browser.hxx
+++ b/src/browser.hxx
@@ -81,7 +81,7 @@ namespace Browser {
 		bool OnPopupBrowserViewCreated(CefRefPtr<CefBrowserView>, CefRefPtr<CefBrowserView>, bool) override;
 		void OnBrowserCreated(CefRefPtr<CefBrowserView>, CefRefPtr<CefBrowser>) override;
 		void OnBrowserDestroyed(CefRefPtr<CefBrowserView>, CefRefPtr<CefBrowser>) override;
-		cef_chrome_toolbar_type_t GetChromeToolbarType() override;
+		cef_chrome_toolbar_type_t GetChromeToolbarType();
 
 		/* CefRequestHandler functions */
 		CefRefPtr<CefResourceRequestHandler> GetResourceRequestHandler(


### PR DESCRIPTION
As of https://github.com/chromiumembedded/cef/commit/ef6ae3071d065455aa21105a9449dd333878aa8d (Sep 14, 2023) override on `ChromeToolbarType GetChromeToolbarType()` will error out as its definition has changed. There's few options:

* This PR: remove explicit override to keep backwards compatibility with older CEF like 114 binary currently provided by you, or
* Keep override, update definition to `GetChromeToolbarType(CefRefPtr<CefBrowserView> browser_view)` and build against newer CEF.