### PR TITLE
Change window close logic to prevent hung process

### DIFF
--- a/src/browser/client.hxx
+++ b/src/browser/client.hxx
@@ -100,7 +100,6 @@ namespace Browser {
 			IMPLEMENT_REFCOUNTING(Client);
 
 			bool is_closing;
-			size_t closing_windows_remaining;
 			bool show_devtools;
 			std::filesystem::path config_dir;
 			std::filesystem::path data_dir;


### PR DESCRIPTION
Currently whenever we arrive at `OnBeforeClose()`, `is_closing` is always false and I believe `closing_windows_remaining` can never be 0 here, so the check against it will always fail. This means that we never actually get into the `Exit()` path which closes the application eventually. This can be easily tested by running the application in a terminal, closing all the GUI windows and observing that the program stays running with bunch of processes until killed. 

I tried understanding the current logic, but couldn't really figure out what was intended with the `closing_windows_remaining` part. I had my hand at adapting it to what made sense to me, and it seems to work fine. Though I don't have too much experience with CEF so take it with a grain of salt.

So with this PR, `DoClose()` logic is not changed, it removes the closed window from the windows vector and OS closes the window. `OnBeforeClose()` which is called next checks whether the windows vector is empty, if there are still any windows left, we don't continue to `Exit()`. `Exit()` is only called when the application is fine to quit, and this eventually calls `CefQuitMessageLoop()` that quits the app.

After this PR `CountBrowsers()` is left unused. If you think there's a better way to fix the initial issue, take this as a bug report instead.
