### PR TITLE
add JAVA_HOME check for posix window launcher

### DIFF
--- a/src/browser/window_launcher_posix.cxx
+++ b/src/browser/window_launcher_posix.cxx
@@ -449,7 +449,8 @@ CefRefPtr<CefResourceRequestHandler> Browser::Launcher::LaunchRuneliteJar(CefRef
 	if (java_home) {
 		java_home_str = std::string(java_home) + "/bin/java";
 		if (!std::filesystem::exists(java_home_str)) {
-			const char* data = "JAVA_HOME environment variable is malformed or incorrect\n";
+			char data [100];
+			sprintf(data, "JAVA_HOME environment variable is malformed or incorrect. Expected to find file at %s/bin/java\n", java_home);
 			return new ResourceHandler(reinterpret_cast<const unsigned char*>(data), strlen(data), 400, "text/plain");
 		}
 	}
@@ -499,7 +500,8 @@ CefRefPtr<CefResourceRequestHandler> Browser::Launcher::LaunchHdosJar(CefRefPtr<
 	std::string java_path_str = std::string(java_home) + "/bin/java";
 	
 	if (!std::filesystem::exists(java_path_str)) {
-		const char* data = "JAVA_HOME environment variable is malformed or incorrect\n";
+		char data [100];
+		sprintf(data, "JAVA_HOME environment variable is malformed or incorrect. Expected to find file at %s/bin/java\n", java_home);
 		return new ResourceHandler(reinterpret_cast<const unsigned char*>(data), strlen(data), 400, "text/plain");
 	}
 

--- a/src/browser/window_launcher_posix.cxx
+++ b/src/browser/window_launcher_posix.cxx
@@ -446,7 +446,13 @@ CefRefPtr<CefResourceRequestHandler> Browser::Launcher::LaunchRuneliteJar(CefRef
 	// set up argv for the new process
 	const char* java_home = getenv("JAVA_HOME");
 	std::string java_home_str;
-	if (java_home) java_home_str = std::string(java_home) + "/bin/java";
+	if (java_home) {
+		java_home_str = std::string(java_home) + "/bin/java";
+		if (!std::filesystem::exists(java_home_str)) {
+			const char* data = "JAVA_HOME environment variable is malformed or incorrect\n";
+			return new ResourceHandler(reinterpret_cast<const unsigned char*>(data), strlen(data), 400, "text/plain");
+		}
+	}
 	std::string arg_home = "-Duser.home=" + user_home;
 	std::string arg_jvm_argument_home = "-J" + arg_home;
 	std::string path_str = jar_path.string();
@@ -492,6 +498,11 @@ CefRefPtr<CefResourceRequestHandler> Browser::Launcher::LaunchHdosJar(CefRefPtr<
 	const char* env_key_java_path = "BOLT_JAVA_PATH=";
 	std::string java_path_str = std::string(java_home) + "/bin/java";
 	
+	if (!std::filesystem::exists(java_path_str)) {
+		const char* data = "JAVA_HOME environment variable is malformed or incorrect\n";
+		return new ResourceHandler(reinterpret_cast<const unsigned char*>(data), strlen(data), 400, "text/plain");
+	}
+
 	std::filesystem::path java_proxy_bin_path = std::filesystem::current_path();
 	java_proxy_bin_path.append("java-proxy");
 	std::filesystem::path java_proxy_data_dir_path = this->data_dir;


### PR DESCRIPTION
Adds a check to see if the file `$JAVA_HOME/bin/java` exists in the posix HDOS and Runelite launcher functions, using [std::filesystem::exists](https://en.cppreference.com/w/cpp/filesystem/exists)

The error message could probably be better, but this is what it currently looks like:
![Screenshot_20240222_015614](https://github.com/Adamcake/Bolt/assets/10724538/3a51b93e-ac4c-4035-bfd0-2217a22a4fe5)
