### PR TITLE
GitHub actions windows build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 env:
   CEF_VERSION: '114.0.5735.199-x'
   LUAJIT_VERSION: '2.1'
-  ENABLE_WINDOWS_RELEASES: 'true'
+  ENABLE_WINDOWS_RELEASES: 'false'
 
 jobs:
   build-windows-project:          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,4 +143,3 @@ jobs:
           cd Bolt
           Compress-Archive -Path D:\a\Bolt\Bolt\install-location\bolt-launcher -DestinationPath D:\a\Bolt\Bolt\Bolt-Windows.zip
           gh release upload ${{ github.event.release.tag_name }} D:\a\Bolt\Bolt\Bolt-Windows.zip
-          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
       - published # Automatically build and publish artifacts on release (gated behind ENABLE_WINDOWS_RELEASES)
 
 env:
-  CEF_VERSION: '114.0.5735.199-x'
+  CEF_VERSION: '114.0.5735.199'
   LUAJIT_VERSION: '2.1'
   ENABLE_WINDOWS_RELEASES: 'false'
 
@@ -82,7 +82,7 @@ jobs:
       - name: Download CEF
         if: steps.restore-cef-cache.outputs.cache-hit != 'true'
         run: |
-          Invoke-WebRequest -Uri 'https://adamcake.com/cef/cef-114.0.5735.199-windows64-minimal-ungoogled.zip' -OutFile 'cef.zip'
+          Invoke-WebRequest -Uri 'https://adamcake.com/cef/cef-${{ env.CEF_VERSION }}-windows64-minimal-ungoogled.zip' -OutFile 'cef.zip'
           Expand-Archive -Path 'cef.zip' -DestinationPath 'cef'
       
       - name: Save CEF to Cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,141 @@
+name: Build
+on:
+  push:
+    branches:
+      - master # Automatically build on push to master
+  pull_request:
+    branches:
+      - master # Automatically build on pull request to master
+  release:
+    types: 
+      - published # Automatically build and publish artifacts on release (gated behind ENABLE_WINDOWS_RELEASES)
+
+env:
+  CEF_VERSION: '114.0.5735.199-x'
+  LUAJIT_VERSION: '2.1'
+  ENABLE_WINDOWS_RELEASES: 'true'
+
+jobs:
+  build-windows-project:          
+    name: Build Project
+    runs-on: windows-2022
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v4.2.0
+        with:
+          path: Bolt
+          submodules: recursive
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v2
+        with:
+          vs-version: 17.0
+
+      - uses: ilammy/msvc-dev-cmd@v1.13.0
+        with:
+          arch: x64
+
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.30.x'
+          
+      - name: Create Directories 
+        run: |
+          mkdir cef
+
+      - name: Cache LuaJIT
+        id: cache-luajit
+        uses: actions/cache@v4
+        with:
+          path: LuaJIT
+          key: 'windows-luajit-${{ env.LUAJIT_VERSION }}'
+
+      - name: Checkout LuaJIT
+        if: steps.cache-luajit.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4.2.0
+        with:
+          path: LuaJIT
+          repository: LuaJIT/LuaJIT
+          ref: v${{ env.LUAJIT_VERSION }}
+
+      - name: Build LuaJIT
+        if: steps.cache-luajit.outputs.cache-hit != 'true'
+        run: |
+          cd LuaJIT/src
+          .\msvcbuild.bat
+
+      - name: Restore CEF from Cache
+        id: restore-cef-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: cef
+          key: 'windows-cef-${{ env.CEF_VERSION }}'
+
+      - name: Download CEF
+        if: steps.restore-cef-cache.outputs.cache-hit != 'true'
+        run: |
+          Invoke-WebRequest -Uri 'https://adamcake.com/cef/cef-114.0.5735.199-windows64-minimal-ungoogled.zip' -OutFile 'cef.zip'
+          Expand-Archive -Path 'cef.zip' -DestinationPath 'cef'
+      
+      - name: Save CEF to Cache
+        if: steps.restore-cef-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: cef
+          key: 'windows-cef-${{ env.CEF_VERSION }}'
+      
+      - name: Copy CEF to Bolt
+        run: Copy-Item -Path (Get-ChildItem -Path "cef" -Directory | Select-Object -First 1).FullName -Destination "Bolt\cef\dist" -Recurse
+
+      # At this point the file tree looks like
+      # D:\a\Bolt\Bolt
+      # - LuaJIT
+      #   - <whole luaJIT source>
+      # - Bolt
+      #   - <whole Bolt source>
+      #   - cef
+      #     - dist
+      #       - <CEF release distribution>
+      #
+      # The tree has many nested Bolt dirs because of how GHA works.
+      # The first two Bolt dirs (D:\a\Bolt\Bolt) are the workspace provided by github.
+      # Github always does it this way.
+      # Then github normally clones directly in to the workspace with a folder of the repo name. 
+      # However for our usecase we clone multiple repos, so we have D:\a\Bolt\Bolt\{LuaJIT, Bolt}
+      - name: Build Project
+        uses: threeal/cmake-action@v2.0.0
+        with:
+          source-dir: Bolt # The directory where CMakeLists.txt is located
+          build-dir: build # Makes it so that the build directory is set to Bold/build
+          generator: Visual Studio 17
+          options: | 
+            BOLT_LUAJIT_DIR=D:\a\Bolt\Bolt\LuaJIT\src
+            CMAKE_BUILD_TYPE=Release
+            BOLT_CEF_INSTALLDIR=D:\a\Bolt\Bolt\install-location
+          build-args: --config Release -j 4
+      
+      # Installs to D:\a\Bolt\Bolt\install-location\bolt-launcher\*
+      - name: Create Release
+        run: cmake --install build/
+      
+      # Uploads D:\a\Bolt\Bolt\install-location as a zip
+      # With `bolt-launcher` as the root directory of the zip file
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Bolt-Windows-${{ github.sha }}
+          path: D:\a\Bolt\Bolt\install-location
+  
+      # Uploads the zip file to the release matching the format of the above step
+      # Such that build artifacts and release artifacts are the same
+      - name: Attach Bolt Artifact to Release
+        if: github.event_name == 'release' && env.ENABLE_WINDOWS_RELEASES == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # In the script below we cd in to Bolt first, because otherwise the gh command will fail.
+        run: |
+          cd Bolt
+          Compress-Archive -Path D:\a\Bolt\Bolt\install-location\bolt-launcher -DestinationPath D:\a\Bolt\Bolt\Bolt-Windows.zip
+          gh release upload ${{ github.event.release.tag_name }} D:\a\Bolt\Bolt\Bolt-Windows.zip
+          

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,15 +44,15 @@ jobs:
         run: |
           mkdir cef
 
-      - name: Cache LuaJIT
-        id: cache-luajit
-        uses: actions/cache@v4
+      - name: Restore LuaJIT from Cache
+        id: restore-cache-luajit
+        uses: actions/cache/restore@v4
         with:
           path: LuaJIT
           key: 'windows-luajit-${{ env.LUAJIT_VERSION }}'
 
       - name: Checkout LuaJIT
-        if: steps.cache-luajit.outputs.cache-hit != 'true'
+        if: steps.restore-cache-luajit.outputs.cache-hit != 'true'
         uses: actions/checkout@v4.2.0
         with:
           path: LuaJIT
@@ -60,10 +60,17 @@ jobs:
           ref: v${{ env.LUAJIT_VERSION }}
 
       - name: Build LuaJIT
-        if: steps.cache-luajit.outputs.cache-hit != 'true'
+        if: steps.restore-cache-luajit.outputs.cache-hit != 'true'
         run: |
           cd LuaJIT/src
           .\msvcbuild.bat
+
+      - name: Save LuaJIT to Cache
+        if: steps.restore-cache-luajit.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: LuaJIT
+          key: 'windows-luajit-${{ env.LUAJIT_VERSION }}'
 
       - name: Restore CEF from Cache
         id: restore-cef-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         id: restore-cef-cache
         uses: actions/cache/restore@v4
         with:
-          path: cef
+          path: Bolt\cef\dist
           key: 'windows-cef-${{ env.CEF_VERSION }}'
 
       - name: Download CEF
@@ -84,17 +84,15 @@ jobs:
         run: |
           Invoke-WebRequest -Uri 'https://adamcake.com/cef/cef-${{ env.CEF_VERSION }}-windows64-minimal-ungoogled.zip' -OutFile 'cef.zip'
           Expand-Archive -Path 'cef.zip' -DestinationPath 'cef'
-      
+          Copy-Item -Path (Get-ChildItem -Path "cef" -Directory | Select-Object -First 1).FullName -Destination "Bolt\cef\dist" -Recurse
+
       - name: Save CEF to Cache
         if: steps.restore-cef-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: cef
+          path: Bolt\cef\dist
           key: 'windows-cef-${{ env.CEF_VERSION }}'
       
-      - name: Copy CEF to Bolt
-        run: Copy-Item -Path (Get-ChildItem -Path "cef" -Directory | Select-Object -First 1).FullName -Destination "Bolt\cef\dist" -Recurse
-
       # At this point the file tree looks like
       # D:\a\Bolt\Bolt
       # - LuaJIT


### PR DESCRIPTION
This sets up automated compilation/artifact generation for windows builds. I'll have a follow-up PR which will build on linux soon.

The primary benefit of this is having validation on every commit to master that the build works correctly, as well as having PRs automatically build and test the changeset.

You can see what this looks like on the PR I have in my repo here: https://github.com/Jacoby6000/Bolt/pull/1
  * Note the green checkmarks next to each commit hash
  * Each checkmark has an associated build and artifact that can be viewed. eg: [7572d29](https://github.com/Jacoby6000/Bolt/actions/runs/11155332593)
 
You can see the built windows artifact for the commit/github actions run
And if set `ENABLE_WINDOWS_RELEASES` to `true`, you can have releases automatically attach a windows artifact, as seen in
  * The release itself: https://github.com/Jacoby6000/Bolt/releases/tag/test-release
  * The github actions build for that release: https://github.com/Jacoby6000/Bolt/actions/runs/11155093841

Release artifacts are currently built when a release is published and `ENABLE_WINDOWS_RELEASES` is `true` I can change this behavior if you'd like.