### PR TITLE
Update README.md to include CEF binary cmake note

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ If building with GCC, you need version 13.1 or later. If building with Clang, yo
   - note: build types "Debug" and "Release" are supported
   - note: if you have Ninja installed, specify `-G Ninja` for much faster builds
   - note: specify CC and CXX env variables at this stage to direct cmake to the C and C++ compilers you want it to use
+  - note: if you downloaded a binary distribution of CEF, you'll have to rename the `./cef/cef_binary_xxxx...` folder to `./cef/dist` before running `cmake`
 - `cmake --build build`
 - `cmake --install build --prefix build`
   - note: the last line creates a staging build in the `build` directory, this needs to be done between changing and running the program every time


### PR DESCRIPTION


The instructions said to visit [https://adamcake.com/cef](https://adamcake.com/cef) and I downloaded `cef-114.0.5735.134-linux-x86_64-minimal-ungoogled.tar.gz` for my system, which gave me a folder called `cef_binary_114.2.11+g87c8807+chromium-114.0.5735.134_linux64_minimal`. I placed this in the `cef` folder as the instructions stated. However, when trying to run the first `cmake` command, I ran into an issue where it couldn't find the CEF distribution. I looked into the `CMakeLists.txt` file and saw `set(CEF_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/cef/dist")`.

I ended up renaming that `cef_binary_114.2.11+g87c8807+chromium-114.0.5735.134_linux64_minimal` folder to `dist` and it then went through.

This commit adds a note to do this renaming, as I didn't see this instruction anywhere in the README.