### PR TITLE
library: Add xywh to window

### DIFF
--- a/src/library/doc/doc.texi
+++ b/src/library/doc/doc.texi
@@ -1689,6 +1689,17 @@ end)
 
 @eventobjectwarning{}
 
+@node window-xywh
+@subsection xywh
+
+Returns the x, y, width and height of this window.
+
+@example lua
+@verbatim
+local x, y, w, h = mywindow:xywh()
+@end verbatim
+@end example
+
 @node window-onmousemotion
 @subsection onmousemotion
 
@@ -1958,6 +1969,12 @@ window:startreposition}.
 
 Cancels repositioning for this browser. @xref{window-cancelreposition,,
 window:cancelreposition}.
+
+@node embeddedbrowser-xywh
+@subsection xywh
+
+Returns the new x, y, width and height for this browser. @xref{window-xywh,,
+window:xywh}.
 
 @node embeddedbrowser-enablecapture
 @subsection enablecapture

--- a/src/library/doc/doc.texi
+++ b/src/library/doc/doc.texi
@@ -1609,17 +1609,6 @@ local id = mywindow:id()
 @end verbatim
 @end example
 
-@node window-size
-@subsection size
-
-Returns the width and height of the window.
-
-@example lua
-@verbatim
-local width, height = mywindow:size()
-@end verbatim
-@end example
-
 @node window-clear
 @subsection clear
 

--- a/src/library/plugin/plugin_api.c
+++ b/src/library/plugin/plugin_api.c
@@ -1159,15 +1159,6 @@ static int api_window_id(lua_State* state) {
     return 1;
 }
 
-static int api_window_size(lua_State* state) {
-    struct EmbeddedWindow* window = require_self_userdata(state, "size");
-    _bolt_rwlock_lock_read(&window->lock);
-    lua_pushinteger(state, window->metadata.width);
-    lua_pushinteger(state, window->metadata.height);
-    _bolt_rwlock_unlock_read(&window->lock);
-    return 2;
-}
-
 static int api_window_subimage(lua_State* state) {
     const struct EmbeddedWindow* window = require_self_userdata(state, "subimage");
     const lua_Integer x = luaL_checkinteger(state, 2);
@@ -1209,10 +1200,12 @@ static int api_window_cancelreposition(lua_State* state) {
 
 static int api_window_xywh(lua_State* state) {
     struct EmbeddedWindow* window = require_self_userdata(state, "xywh");
+    _bolt_rwlock_lock_read(&window->lock);
     lua_pushinteger(state, window->metadata.x);
     lua_pushinteger(state, window->metadata.y);
     lua_pushinteger(state, window->metadata.width);
     lua_pushinteger(state, window->metadata.height);
+    _bolt_rwlock_unlock_read(&window->lock);
     return 4;
 }
 
@@ -2156,7 +2149,6 @@ static struct ApiFuncTemplate surface_functions[] = {
 static struct ApiFuncTemplate window_functions[] = {
     BOLTFUNC(close, window),
     BOLTFUNC(id, window),
-    BOLTFUNC(size, window),
     BOLTFUNC(clear, window),
     BOLTFUNC(subimage, window),
     BOLTFUNC(startreposition, window),

--- a/src/library/plugin/plugin_api.c
+++ b/src/library/plugin/plugin_api.c
@@ -1207,6 +1207,15 @@ static int api_window_cancelreposition(lua_State* state) {
     return 0;
 }
 
+static int api_window_xywh(lua_State* state) {
+    struct EmbeddedWindow* window = require_self_userdata(state, "xywh");
+    lua_pushinteger(state, window->metadata.x);
+    lua_pushinteger(state, window->metadata.y);
+    lua_pushinteger(state, window->metadata.width);
+    lua_pushinteger(state, window->metadata.height);
+    return 4;
+}
+
 static int api_render3d_vertexcount(lua_State* state) {
     const struct Render3D* render = require_self_userdata(state, "vertexcount");
     lua_pushinteger(state, render->vertex_count);
@@ -2153,6 +2162,7 @@ static struct ApiFuncTemplate window_functions[] = {
     BOLTFUNC(startreposition, window),
     BOLTFUNC(cancelreposition, window),
     BOLTFUNC(onreposition, window),
+    BOLTFUNC(xywh, window),
     BOLTFUNC(onmousemotion, window),
     BOLTFUNC(onmousebutton, window),
     BOLTFUNC(onmousebuttonup, window),
@@ -2175,6 +2185,7 @@ static struct ApiFuncTemplate embeddedbrowser_functions[] = {
     BOLTFUNC(sendmessage, embeddedbrowser),
     BOLTFUNC(startreposition, window),
     BOLTFUNC(cancelreposition, window),
+    BOLTFUNC(xywh, window),
     BOLTFUNC(enablecapture, embeddedbrowser),
     BOLTFUNC(disablecapture, embeddedbrowser),
     BOLTFUNC(showdevtools, embeddedbrowser),


### PR DESCRIPTION
Adds a function to get the position and dimensions of a window.

I added this since `onreposition` is handled internally for embedded browsers: https://bolt.adamcake.com/doc#objects_002dembeddedbrowser