### PR TITLE
OSRS official client linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ When doing the initial cmake setup step, the following options exist which you m
   - This is solved by setting the JAVA_HOME environment variable.
   - This is usually located in /usr/lib/jvm, so, it might look like this:  
     `export JAVA_HOME="/usr/lib/jvm/java-17-openjdk-17.0.9.0.9-3.fc39.x86_64"`
+- umu-launcher/wine
+  - Another issue you may see in the console when trying to launch the OSRS Official Client.
+  - This can be solved by installing a package with your package manager.  
+    Something similar to `umu-launcher`. If not available in your package manager, see https://github.com/Open-Wine-Components/umu-launcher.
+  - Bolt will also utilize your system wine if umu-run is not available. This will generally yield worse performance results.
 
 ## Contributing
 

--- a/src/browser/window_launcher_posix.cxx
+++ b/src/browser/window_launcher_posix.cxx
@@ -50,7 +50,7 @@ bool FindJava(const char* java_home, std::string& out) {
 // similar to FindJava but for wine/proton.
 // true on success, false on failure, out is undefined on failure
 bool FindWine(std::string& out) {
-	if (FindInPath("proton", out)) return true;
+	if (FindInPath("umu-run", out)) return true;
 	return FindInPath("wine", out);
 }
 
@@ -339,10 +339,10 @@ CefRefPtr<CefResourceRequestHandler> Browser::Launcher::LaunchRs3App(CefRefPtr<C
 CefRefPtr<CefResourceRequestHandler> Browser::Launcher::LaunchOsrsExe(CefRefPtr<CefRequest> request, std::string_view query) {
 	const CefRefPtr<CefPostData> post_data = request->GetPostData();
 
-	// try to find proton or wine
+	// try to find umu-run or wine
 	std::string wine;
 	if (!FindWine(wine)) {
-		QSENDSTR("Couldn't find proton or wine in PATH", 500);
+		QSENDSTR("Couldn't find umu-run or wine in PATH", 500);
 	}
 
 	// parse query
@@ -406,6 +406,11 @@ CefRefPtr<CefResourceRequestHandler> Browser::Launcher::LaunchOsrsExe(CefRefPtr<
 		if (has_jx_session_id) setenv("JX_SESSION_ID", jx_session_id.data(), true);
 		if (has_jx_character_id) setenv("JX_CHARACTER_ID", jx_character_id.data(), true);
 		if (has_jx_display_name) setenv("JX_DISPLAY_NAME", jx_display_name.data(), true);
+		// game id from steam for OSRS. This allows umu to apply any necessary protonfixes
+		setenv("GAMEID", "1343370", true);
+		// tell umu to use the latest GE Proton it can find, which will perform better in most cases
+		setenv("PROTONPATH", "GE-Proton", true);
+
 		execv(*argv, argv);
 	}
 

--- a/src/browser/window_launcher_posix.cxx
+++ b/src/browser/window_launcher_posix.cxx
@@ -47,7 +47,7 @@ bool FindJava(const char* java_home, std::string& out) {
 	return FindInPath("java", out);
 }
 
-// similar to FindJava but for wine/proton.
+// similar to FindJava but for wine/umu-run.
 // true on success, false on failure, out is undefined on failure
 bool FindWine(std::string& out) {
 	if (FindInPath("umu-run", out)) return true;
@@ -410,6 +410,13 @@ CefRefPtr<CefResourceRequestHandler> Browser::Launcher::LaunchOsrsExe(CefRefPtr<
 		setenv("GAMEID", "1343370", true);
 		// tell umu to use the latest GE Proton it can find, which will perform better in most cases
 		setenv("PROTONPATH", "GE-Proton", true);
+
+		// This is needed due to proton's pressure vessel changing the mount point of /app to /run/parent/app inside of pressure vessel.
+		// It tries to chdir back to /app/opt/bolt-launcher which will no longer exist. Chdir to data_dir works to work around this.
+		if (chdir(this->data_dir.c_str())) {
+			fmt::print("[B] new process was unable to chdir: {}\n", errno);
+			exit(1);
+		}
 
 		execv(*argv, argv);
 	}


### PR DESCRIPTION
#124 

This adds support for launching the OSRS official client using umu-run, or wine as a fallback.