### PR TITLE
Add support for running multiple clients in proton

### DIFF
--- a/src/browser/window_launcher_posix.cxx
+++ b/src/browser/window_launcher_posix.cxx
@@ -422,6 +422,8 @@ CefRefPtr<CefResourceRequestHandler> Browser::Launcher::LaunchOsrsExe(CefRefPtr<
 		setenv("GAMEID", "1343370", true);
 		// tell umu to use the latest GE Proton it can find, which will perform better in most cases
 		setenv("PROTONPATH", "GE-Proton", true);
+		// allow proton to run multiple official clients at once
+		setenv("PROTON_VERB", "runinprefix", true);
 		BoltExec(argv);
 	}
 


### PR DESCRIPTION
Addresses #159. See https://github.com/Open-Wine-Components/umu-launcher/wiki/Frequently-asked-questions-(FAQ)#how-do-i-run-more-than-one-game-in-the-same-wine-prefix 

By default, proton only allows one process running in a prefix. This environment variable overrides that behavior.