### PR TITLE
fix: disable clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true


### PR DESCRIPTION
Looks like `clang-format` isn't used to format the project - putting this file in the root repo ensures editors with clangd don't try to format the project.

Happy to just leave this locally & locally gitignore it if you don't want the file in the repo.
