### PR TITLE
cmake: support building with Fedora's system CEF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,11 @@ endif()
 if(NOT BOLT_CEF_DLLWRAPPER)
     set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CEF_ROOT}/cmake")
     find_package(CEF REQUIRED)
-    add_subdirectory(${CEF_LIBCEF_DLL_WRAPPER_PATH} libcef_dll_wrapper)
+    if(NOT TARGET libcef_dll_wrapper)
+        # Some distros (like Fedora) define the libcef_dll_wrapper target in FindCEF.cmake
+        # We check if the target already exists before attempting to add it as a subdirectory
+        add_subdirectory(${CEF_LIBCEF_DLL_WRAPPER_PATH} libcef_dll_wrapper)
+    endif()
 endif()
 
 # select implementations for OS-specific behaviour


### PR DESCRIPTION
For reference, here's Fedora's system CEF `FindCEF.cmake` file https://src.fedoraproject.org/rpms/cef/blob/a6685f4c36f56c1933a00a4636983e79db5cac01/f/FindCEF.cmake#_85

I've tested this on Fedora 42, and it allows me to build Bolt without specifying any extra CEF CMake flags.