### PR TITLE
cmake: prefer pkgconf for finding Linux deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,7 +473,12 @@ if(UNIX AND NOT APPLE)
         set_target_properties(bolt PROPERTIES INSTALL_RPATH "$ORIGIN")
     endif()
 
-    target_link_libraries(bolt PUBLIC "${BOLT_LIBCEF_DIRECTORY}/libcef.so")
+    if(TARGET CEF::Library)
+        message(STATUS "Linking with FindPackage version of CEF::Library")
+        target_link_libraries(bolt PUBLIC CEF::Library)
+    else()
+        target_link_libraries(bolt PUBLIC "${BOLT_LIBCEF_DIRECTORY}/libcef.so")
+    endif()
 
     find_package(PkgConfig REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,11 +472,20 @@ if(UNIX AND NOT APPLE)
     if(NOT BOLT_SKIP_RPATH)
         set_target_properties(bolt PROPERTIES INSTALL_RPATH "$ORIGIN")
     endif()
-    target_compile_definitions(bolt PUBLIC HAS_LIBARCHIVE)
+
     target_link_libraries(bolt PUBLIC "${BOLT_LIBCEF_DIRECTORY}/libcef.so")
-    target_link_libraries(bolt PUBLIC "X11")
-    target_link_libraries(bolt PUBLIC "xcb")
-    target_link_libraries(bolt PUBLIC "archive")
+
+    find_package(PkgConfig REQUIRED)
+
+    pkg_check_modules(X11 REQUIRED IMPORTED_TARGET x11)
+    target_link_libraries(bolt PUBLIC PkgConfig::X11)
+
+    pkg_check_modules(XCB REQUIRED IMPORTED_TARGET xcb)
+    target_link_libraries(bolt PUBLIC PkgConfig::XCB)
+
+    pkg_check_modules(LIBARCHIVE REQUIRED IMPORTED_TARGET libarchive)
+    target_link_libraries(bolt PUBLIC PkgConfig::LIBARCHIVE)
+    target_compile_definitions(bolt PUBLIC HAS_LIBARCHIVE)
 elseif(WIN32)
     set_target_properties(bolt PROPERTIES WIN32_EXECUTABLE TRUE)
     target_link_libraries(bolt PUBLIC "${CEF_ROOT}/${CMAKE_BUILD_TYPE}/libcef.lib")

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ If you accidentally cloned without submodules (no `modules` directory), you can 
 Place your entire CEF binary distribution folder inside the `cef` directory with the name "dist", or create a symbolic link with the same effect.
 
 If building on Linux, the following are required:
+- pkgconf (`pkgconf` or `pkg-config` on most package managers)
 - X11 development libraries (`libX11-devel` or `libx11-dev` on most package managers)
 - xcb development libraries (`libxcb-devel` or `libxcb1-dev` on most package managers)
 - libarchive development libraries (`libarchive-devel` or `libarchive-dev` on most package managers)

--- a/src/library/CMakeLists.txt
+++ b/src/library/CMakeLists.txt
@@ -9,8 +9,13 @@ if(UNIX AND NOT APPLE)
     add_library(${BOLT_PLUGIN_LIB_NAME} SHARED so/main.c plugin/plugin.c plugin/plugin_api.c gl.c
     rwlock/rwlock_posix.c ipc_posix.c plugin/plugin_posix.c ../../modules/hashmap/hashmap.c
     ../miniz/miniz.c ../sha256/sha256.c ../../modules/spng/spng/spng.c)
-    target_link_libraries(${BOLT_PLUGIN_LIB_NAME} luajit-5.1)
-    target_include_directories(${BOLT_PLUGIN_LIB_NAME} PUBLIC "${BOLT_LUAJIT_INCLUDE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/../miniz")
+
+    find_package(PkgConfig REQUIRED)
+
+    pkg_check_modules(LUAJIT REQUIRED IMPORTED_TARGET luajit)
+    target_link_libraries(${BOLT_PLUGIN_LIB_NAME} PUBLIC PkgConfig::LUAJIT)
+
+    target_include_directories(${BOLT_PLUGIN_LIB_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../miniz")
     install(TARGETS ${BOLT_PLUGIN_LIB_NAME} DESTINATION "${BOLT_LIBDIR}")
 endif()
 if (WIN32)


### PR DESCRIPTION
Not sure if this really counts as adding a dependency - every development setup I've set up has had either `pkgconf` or `pkg-config` preinstalled, so I can revert the readme update if you prefer.