### PR TITLE
chore: use wine-staging instead of proton

### DIFF
--- a/src/browser/window_launcher_posix.cxx
+++ b/src/browser/window_launcher_posix.cxx
@@ -418,12 +418,18 @@ CefRefPtr<CefResourceRequestHandler> Browser::Launcher::LaunchOsrsExe(CefRefPtr<
 	pid_t pid = fork();
 	if (pid == 0) {
 		SETUPCHILD()
-		// game id from steam for OSRS. This allows umu to apply any necessary protonfixes
+
+		const std::filesystem::path wineprefix = this->data_dir / "osrs_official_wine_prefix";
+
+		// Place default WINEPREFIX inside bolt data directory
+		setenv("WINEPREFIX", wineprefix.c_str(), false);
+
+		// These are only relevant when someone is using umu-launcher.
+		// Do not allow gameid override since that should not need to happen.
 		setenv("GAMEID", "1343370", true);
-		// tell umu to use the latest GE Proton it can find, which will perform better in most cases
-		setenv("PROTONPATH", "GE-Proton", true);
-		// allow proton to run multiple official clients at once
-		setenv("PROTON_VERB", "runinprefix", true);
+		setenv("PROTONPATH", "GE-Latest", false);
+		setenv("PROTON_VERB", "runinprefix", false);
+
 		BoltExec(argv);
 	}
 


### PR DESCRIPTION
- Use wine staging instead of umu. We can move back to umu if any proton patches are needed.
- Set wineprefix to XDG_DATA_HOME to persist between runs
- Allow the user to overwrite protonpath, proton_verb, and wineprefix

This addresses #173 which is either a bug in proton-ge, or a path mismatch between steam runtime container wrapped in the flatpak container.

This is a simpler approach until we for sure need proton, and users can still use umu if they install it on their system outside of the flatpak. 