### PR TITLE
docs: Add nix package manager to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Bolt, as well as the other Linux community projects, is being discussed at [7orm
 For Linux/Steamdeck users, Bolt is available on the following package managers:
 - flatpak: `com.adamcake.Bolt`
 - AUR: `bolt-launcher`
+- nix: `bolt-launcher`
 
 Instructions on installing flatpak can be found [here](https://flatpak.org/setup/)
 Others should see the "releases" section on the right.


### PR DESCRIPTION
Add nix package manager entry to README.
https://search.nixos.org/packages?channel=unstable&query=bolt-launcher